### PR TITLE
feat: added banner and update subscription check to make maintained actions free for public repos

### DIFF
--- a/.github/workflows/actions_release.yml
+++ b/.github/workflows/actions_release.yml
@@ -9,7 +9,11 @@ on:
       script:
         description: "Specify a script to run after audit fix"
         required: false
-        default: "yarn build"  
+        default: "yarn build"
+      node_version:
+        description: "Specify Node.js version (e.g., '18', '20', 'lts/*')"
+        required: false
+        default: "24"
 
 permissions:
   contents: read
@@ -25,3 +29,4 @@ jobs:
     with:
       tag: "${{ github.event.inputs.tag }}"
       script: ${{ inputs.script || 'yarn build' }}
+      node_version: "${{ github.event.inputs.node_version }}"

--- a/.github/workflows/audit_package.yml
+++ b/.github/workflows/audit_package.yml
@@ -14,7 +14,11 @@ on:
       script:
         description: "Specify a script to run after audit fix"
         required: false
-        default: "yarn build"  
+        default: "yarn build"
+      node_version:
+        description: "Specify Node.js version (e.g., '18', '20', 'lts/*')"
+        required: false
+        default: "24"
 
   schedule:
     - cron: "0 0 * * 1"
@@ -26,6 +30,7 @@ jobs:
       base_branch: ${{ inputs.base_branch || 'main' }}
       package_manager: ${{inputs.package_manager || 'yarn' }}
       script: ${{ inputs.script || 'yarn build' }}
+      node_version: "${{ inputs.node_version || '24' }}"
 
 permissions:
   contents: write

--- a/.github/workflows/auto_cherry_pick.yml
+++ b/.github/workflows/auto_cherry_pick.yml
@@ -18,7 +18,11 @@ on:
       script:
         description: "Specify a script to run after audit fix"
         required: false
-        default: "yarn build"  
+        default: "yarn build"
+      node_version:
+        description: "Specify Node.js version (e.g., '18', '20', 'lts/*')"
+        required: false
+        default: "24"
 
   pull_request:
     types: [opened, synchronize, labeled]
@@ -40,3 +44,4 @@ jobs:
       mode: ${{ github.event_name == 'pull_request' && 'verify' || inputs.mode }}
       package_manager: ${{inputs.package_manager || 'yarn' }}
       script: ${{ inputs.script || 'yarn build' }}
+      node_version: "${{ inputs.node_version || '24' }}"

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -19,7 +19,7 @@ jobs:
 
       - uses: actions/setup-node@2028fbc5c25fe9cf00d9f06a71cc4710d4507903 # v6.0.0
         with:
-          node-version: "20.x"
+          node-version: "24"
 
       - run: yarn install
 

--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+[![StepSecurity Maintained Action](https://raw.githubusercontent.com/step-security/maintained-actions-assets/main/assets/maintained-action-banner.png)](https://docs.stepsecurity.io/actions/stepsecurity-maintained-actions)
+
 # Action Add Labels
 
 ![screenshot](./docs/assets/screenshot.png)

--- a/action.yml
+++ b/action.yml
@@ -17,7 +17,7 @@ inputs:
     description: The number of the issue or pull request.
     required: false
 runs:
-  using: node20
+  using: 'node24'
   main: dist/index.js
 branding:
   icon: bookmark

--- a/dist/index.js
+++ b/dist/index.js
@@ -42,20 +42,41 @@ var __importStar = (this && this.__importStar) || (function () {
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 const github = __importStar(__nccwpck_require__(5438));
 const core = __importStar(__nccwpck_require__(2186));
+const fs = __importStar(__nccwpck_require__(7147));
 const axios_1 = __importStar(__nccwpck_require__(8757));
 async function validateSubscription() {
-    const API_URL = `https://agent.api.stepsecurity.io/v1/github/${process.env.GITHUB_REPOSITORY}/actions/subscription`;
+    const eventPath = process.env.GITHUB_EVENT_PATH;
+    let repoPrivate;
+    if (eventPath && fs.existsSync(eventPath)) {
+        const eventData = JSON.parse(fs.readFileSync(eventPath, 'utf8'));
+        repoPrivate = eventData?.repository?.private;
+    }
+    const upstream = 'actions-ecosystem/action-add-labels';
+    const action = process.env.GITHUB_ACTION_REPOSITORY;
+    const docsUrl = 'https://docs.stepsecurity.io/actions/stepsecurity-maintained-actions';
+    core.info('');
+    core.info('[1;36mStepSecurity Maintained Action[0m');
+    core.info(`Secure drop-in replacement for ${upstream}`);
+    if (repoPrivate === false)
+        core.info('[32m✓ Free for public repositories[0m');
+    core.info(`[36mLearn more:[0m ${docsUrl}`);
+    core.info('');
+    if (repoPrivate === false)
+        return;
+    const serverUrl = process.env.GITHUB_SERVER_URL || 'https://github.com';
+    const body = { action: action || '' };
+    if (serverUrl !== 'https://github.com')
+        body.ghes_server = serverUrl;
     try {
-        await axios_1.default.get(API_URL, { timeout: 3000 });
+        await axios_1.default.post(`https://agent.api.stepsecurity.io/v1/github/${process.env.GITHUB_REPOSITORY}/actions/maintained-actions-subscription`, body, { timeout: 3000 });
     }
     catch (error) {
         if ((0, axios_1.isAxiosError)(error) && error.response?.status === 403) {
-            core.error('Subscription is not valid. Reach out to support@stepsecurity.io');
+            core.error(`[1;31mThis action requires a StepSecurity subscription for private repositories.[0m`);
+            core.error(`[31mLearn how to enable a subscription: ${docsUrl}[0m`);
             process.exit(1);
         }
-        else {
-            core.info('Timeout or API not reachable. Continuing to next step.');
-        }
+        core.info('Timeout or API not reachable. Continuing to next step.');
     }
 }
 async function run() {

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,21 +1,52 @@
 import * as github from '@actions/github';
 import * as core from '@actions/core';
+import * as fs from 'fs';
 import axios, { isAxiosError } from 'axios';
 
 async function validateSubscription(): Promise<void> {
-  const API_URL = `https://agent.api.stepsecurity.io/v1/github/${process.env.GITHUB_REPOSITORY}/actions/subscription`;
+  const eventPath = process.env.GITHUB_EVENT_PATH
+  let repoPrivate: boolean | undefined
 
+  if (eventPath && fs.existsSync(eventPath)) {
+    const eventData = JSON.parse(fs.readFileSync(eventPath, 'utf8'))
+    repoPrivate = eventData?.repository?.private
+  }
+
+  const upstream = 'actions-ecosystem/action-add-labels'
+  const action = process.env.GITHUB_ACTION_REPOSITORY
+  const docsUrl =
+    'https://docs.stepsecurity.io/actions/stepsecurity-maintained-actions'
+
+  core.info('')
+  core.info('[1;36mStepSecurity Maintained Action[0m')
+  core.info(`Secure drop-in replacement for ${upstream}`)
+  if (repoPrivate === false)
+    core.info('[32m✓ Free for public repositories[0m')
+  core.info(`[36mLearn more:[0m ${docsUrl}`)
+  core.info('')
+
+  if (repoPrivate === false) return
+
+  const serverUrl = process.env.GITHUB_SERVER_URL || 'https://github.com'
+  const body: Record<string, string> = {action: action || ''}
+  if (serverUrl !== 'https://github.com') body.ghes_server = serverUrl
   try {
-    await axios.get(API_URL, { timeout: 3000 });
+    await axios.post(
+      `https://agent.api.stepsecurity.io/v1/github/${process.env.GITHUB_REPOSITORY}/actions/maintained-actions-subscription`,
+      body,
+      {timeout: 3000}
+    )
   } catch (error) {
     if (isAxiosError(error) && error.response?.status === 403) {
       core.error(
-        'Subscription is not valid. Reach out to support@stepsecurity.io'
-      );
-      process.exit(1);
-    } else {
-      core.info('Timeout or API not reachable. Continuing to next step.');
+        `[1;31mThis action requires a StepSecurity subscription for private repositories.[0m`
+      )
+      core.error(
+        `[31mLearn how to enable a subscription: ${docsUrl}[0m`
+      )
+      process.exit(1)
     }
+    core.info('Timeout or API not reachable. Continuing to next step.')
   }
 }
 

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,6 +1,6 @@
 {
   "compilerOptions": {
-    "target": "es2020",
+    "target": "ES2024",
     "module": "commonjs",
     "outDir": "./lib",
     "rootDir": "./src",


### PR DESCRIPTION
## Summary

- Added StepSecurity Maintained Action banner to README.md
- Updated subscription validation: public repositories are now free (no API check)
- Upgraded Node.js runtime to node24
- Updated workflow files with configurable node_version input

## Changes by type
- **TypeScript/JS actions**: replaced `validateSubscription()` body, updated action.yml to node24, updated 3 workflow files, rebuilt dist/

## Verification
- [ ] Subscription check skips for public repos
- [ ] Subscription check fires for private repos
- [ ] README banner is present at the top
- [ ] Build passes

Auto-generated by StepSecurity update-propagator. Task ID: 20260423T092801Z